### PR TITLE
PHP Fatal error thrown on do_payment.

### DIFF
--- a/includes/class-payment-gateway.php
+++ b/includes/class-payment-gateway.php
@@ -514,7 +514,7 @@ class WC_Gateway_Simplify_Commerce extends WC_Payment_Gateway_CC {
 			// Charge the customer
 			$data = array(
 				'amount'      => $amount, // In cents. Rounding to avoid floating point errors.
-				'description' => sprintf( __( '%s - Order #%s', 'woocommerce' ), $order->get_order_number() ),
+				'description' => sprintf( __( '#%s', 'woocommerce' ), $order->get_order_number() ), /*this line throw fatal error, as 2 arguments are waiting corresponding value*/
 				'currency'    => strtoupper( get_woocommerce_currency() ),
 				'reference'   => $order->get_id()
 			);


### PR DESCRIPTION
PHP message: PHP Fatal error:  Uncaught ArgumentCountError: 3 arguments are required, 2 given in .../wp-content/plugins/woocommerce-simplify-payment-gateway-plugin-2.2.0/includes/class-payment-gateway.php:517

On my installation, I fixed by removing the unnecessary string format specifier among rest description text.

From this:
'%s - Order #%s'
to this:
'#%s'

Running on PHP8.